### PR TITLE
[Refactor] : 클라이언트에서 파일 전달받아 Flask 전송 리팩토링

### DIFF
--- a/src/main/java/com/alal/backend/controller/view/ViewController.java
+++ b/src/main/java/com/alal/backend/controller/view/ViewController.java
@@ -33,8 +33,8 @@ public class ViewController {
         return "main/imagePage";
     }
 
-    // 클라이언트에서 동영상 파일을 받아 Flask 서버와 통신하여 문자열 리스트를 받음
-    @PostMapping("/video")
+    // 클라이언트에서 파일(mp3, mp4, wav)을 받아 Flask 서버와 통신하여 문자열 리스트를 받음
+    @PostMapping("/file")
     public String voicePost(@RequestParam("file") MultipartFile file,
                             @PageableDefault(size = 30) Pageable pageable,
                             Model model

--- a/src/main/java/com/alal/backend/payload/request/auth/FlaskRequest.java
+++ b/src/main/java/com/alal/backend/payload/request/auth/FlaskRequest.java
@@ -1,0 +1,20 @@
+package com.alal.backend.payload.request.auth;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@Builder
+public class FlaskRequest {
+    private String base64EncodedFile;
+
+    private String fileFormat;
+
+    public static FlaskRequest fromFile(String base64EncodedFile, String fileFormat) {
+        return FlaskRequest.builder()
+                .base64EncodedFile(base64EncodedFile)
+                .fileFormat(fileFormat)
+                .build();
+    }
+}

--- a/src/main/java/com/alal/backend/service/user/MotionService.java
+++ b/src/main/java/com/alal/backend/service/user/MotionService.java
@@ -1,5 +1,6 @@
 package com.alal.backend.service.user;
 
+import com.alal.backend.payload.request.auth.FlaskRequest;
 import com.alal.backend.payload.response.FlaskResponse;
 import com.alal.backend.payload.response.ViewResponse;
 import com.alal.backend.repository.user.MotionRepository;
@@ -15,10 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,11 +32,11 @@ public class MotionService {
 
     @Transactional(readOnly = true)
     public Page<ViewResponse> findUrlByUploadMp4(MultipartFile file, Pageable pageable) {
-        // MultipartFile을 base64 인코딩
-        String base64EncodedVoice = convertMultipartFileToBase64(file);
+        // MultipartFile을 base64 인코딩, 파일 형식 추출
+        FlaskRequest flaskRequest = convertMultipartFileToBase64(file);
 
         // Flask 서버 통신
-        List<FlaskResponse> flaskResponses = communicateWithFlaskServer(base64EncodedVoice);
+        List<FlaskResponse> flaskResponses = communicateWithFlaskServer(flaskRequest);
         List<String> responseMessages = flaskResponses.stream()
                 .map(FlaskResponse::getResponseMessage)
                 .collect(Collectors.toList());
@@ -48,22 +46,26 @@ public class MotionService {
     }
 
     // MultipartFile을 base64로 변환하는 메서드
-    private String convertMultipartFileToBase64(MultipartFile file) {
+    private FlaskRequest convertMultipartFileToBase64(MultipartFile file) {
         try {
             byte[] fileBytes = file.getBytes();
-            return Base64.getEncoder().encodeToString(fileBytes);
+            String fileFormat = file.getContentType() != null ? file.getContentType().split("/")[1] : "";
+
+            FlaskRequest flaskRequest = FlaskRequest.fromFile(Base64.getEncoder().encodeToString(fileBytes), fileFormat);
+            return flaskRequest;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
     // Flask 서버 통신
-    private List<FlaskResponse> communicateWithFlaskServer(String base64EncodedVoice) {
+    private List<FlaskResponse> communicateWithFlaskServer(FlaskRequest flaskRequest) {
         // 파일을 Flask 서버로 전송
         List<FlaskResponse> flaskResponses =  webClient.post()
                 .uri(flaskUrl + "/checkpose/")
                 .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(Collections.singletonMap("pose", base64EncodedVoice))
+                .bodyValue(Map.of("pose", flaskRequest.getBase64EncodedFile(),
+                        "format", flaskRequest.getFileFormat()))
                 .retrieve()
                 .bodyToFlux(FlaskResponse.class)
                 .collectList()


### PR DESCRIPTION
## 연관 이슈
이슈 번호 : #19 

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [x] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 클라이언트에서 파일 전달받아 Flask 전송 리팩토링
- base64 인코딩 파일명, 파일 형식 Dto에 저장
- flask에 파일 형식에 맞춰 파일 생성

## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [x] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->

![image](https://github.com/MTVS-Post-Production/BackEnd/assets/105257665/27f3f652-69eb-4f17-a573-9c3553035cc7)
