### PR TITLE
[Refactor] : 클라이언트에서 문자열 전달받기 리스트에서 단순 문자열로 변경

### DIFF
--- a/src/main/java/com/alal/backend/controller/view/ViewController.java
+++ b/src/main/java/com/alal/backend/controller/view/ViewController.java
@@ -49,9 +49,9 @@ public class ViewController {
 
     // 클라이언트에서 문자열을 받아 Flask 서버와 통신하여 문자열 리스트 반환받음
     @PostMapping("/message")
-    public String messagePost(@RequestBody List<String> messages, Model model,
+    public String messagePost(@RequestBody String message, Model model,
                               @PageableDefault(size = 30) Pageable pageable){
-        Page<ViewResponse> viewResponse = motionService.findGifByMessages(messages, pageable);
+        Page<ViewResponse> viewResponse = motionService.findGifByMessages(message, pageable);
         lastViewResponses = viewResponse;
 
         model.addAttribute("motionUrls", viewResponse);

--- a/src/main/java/com/alal/backend/service/user/MotionService.java
+++ b/src/main/java/com/alal/backend/service/user/MotionService.java
@@ -76,14 +76,14 @@ public class MotionService {
 
     // 메세지를 통한 gif, fbx 찾기
     @Transactional(readOnly = true)
-    public Page<ViewResponse> findGifByMessages(List<String> messages, Pageable pageable) {
+    public Page<ViewResponse> findGifByMessages(String message, Pageable pageable) {
         // Flask 서버 통신
         // 분석한 결과를 문자열 리스트로 반환받음
         List<FlaskResponse> flaskResponses = WebClient.create()
                 .post()
                 .uri(flaskUrl + "/message")
                 .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(Collections.singletonMap("pose", messages))
+                .bodyValue(Collections.singletonMap("pose", message))
                 .retrieve()
                 .bodyToFlux(FlaskResponse.class)
                 .collectList()

--- a/src/test/java/com/alal/backend/service/user/MotionServiceTest.java
+++ b/src/test/java/com/alal/backend/service/user/MotionServiceTest.java
@@ -37,7 +37,7 @@ class MotionServiceTest {
     @Test
     void findGifByMessagesTest(){
         // given
-        List<String> messages = Arrays.asList("chunsic", "dance");
+        String message = "chunsic";
         Pageable pageable = PageRequest.of(0, 30);
 
         List<ViewResponse> expectedResponses = new ArrayList<>();
@@ -49,9 +49,9 @@ class MotionServiceTest {
 
         Page<ViewResponse> expectedPages = new PageImpl<>(expectedResponses, pageable, expectedResponses.size());
 
-        Mockito.when(motionServiceMock.findGifByMessages(messages, pageable)).thenReturn(expectedPages);
+        Mockito.when(motionServiceMock.findGifByMessages(message, pageable)).thenReturn(expectedPages);
         // when
-        Page<ViewResponse> resultPages = motionServiceMock.findGifByMessages(messages, pageable);
+        Page<ViewResponse> resultPages = motionServiceMock.findGifByMessages(message, pageable);
 
         // then
         assertEquals(expectedPages.getContent(), resultPages.getContent());


### PR DESCRIPTION
## 연관 이슈
이슈 번호 : #21 

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Rename
- [x] Test
- [x] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 기존에는 클라이언트에서 문자열 리스트를 받았는데 ai측에 넘겨줄때 "일어나면서 펀치"같은 문자열을 전달할 예정이기에 변경함
- 테스트 코드 수정 완료


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [x] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->