### PR TITLE
[Feat] : 음성 파일 받았을 때, flask 서버에 요청 보내고 base64 문자열 응답

### DIFF
--- a/src/main/java/com/alal/backend/controller/view/ViewController.java
+++ b/src/main/java/com/alal/backend/controller/view/ViewController.java
@@ -2,6 +2,7 @@ package com.alal.backend.controller.view;
 
 import com.alal.backend.payload.request.auth.FbxRequest;
 import com.alal.backend.payload.response.FbxResponse;
+import com.alal.backend.payload.response.FlaskResponse;
 import com.alal.backend.payload.response.ViewResponse;
 import com.alal.backend.service.user.MotionService;
 import lombok.RequiredArgsConstructor;
@@ -37,9 +38,9 @@ public class ViewController {
         return "main/imagePage";
     }
 
-    // 클라이언트에서 파일(mp3, mp4, wav)을 받아 Flask 서버와 통신하여 문자열 리스트를 받음
-    @PostMapping("/file")
-    public String voicePost(@RequestParam("file") MultipartFile file,
+    // 클라이언트에서 동영상 파일(mp4)을 받아 Flask 서버와 통신하여 문자열 리스트를 받음
+    @PostMapping("/video")
+    public String videoPost(@RequestParam("file") MultipartFile file,
                             @PageableDefault(size = 30) Pageable pageable,
                             Model model
                             ) {
@@ -49,6 +50,15 @@ public class ViewController {
         model.addAttribute("motionUrls", viewResponse);
 
         return "main/imagePage";
+    }
+
+    // 클라이언트에서 음성 파일을 받아 Flask 서버와 통신 후 변조된 음성 파일 응답
+    @PostMapping("/voice")
+    @ResponseBody
+    public ResponseEntity<FlaskResponse> voicePost(@RequestParam("file") MultipartFile file
+    ) {
+        FlaskResponse flaskResponse = motionService.uploadAndRespondWithAudioFileSuccess(file);
+        return ResponseEntity.ok(flaskResponse);
     }
 
     // 클라이언트에서 문자열을 받아 Flask 서버와 통신하여 문자열 리스트 반환받음
@@ -63,6 +73,7 @@ public class ViewController {
         return "main/imagePage";
     }
 
+    // 웹에서 다운로드 버튼 클릭 시 /view/result?fbxUrl=... 로 리다이렉트
     @PostMapping("/send/fbx")
     @ResponseBody
     public ResponseEntity<FbxResponse> send(@RequestBody FbxRequest fbxRequest){
@@ -76,7 +87,7 @@ public class ViewController {
         return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
 
-
+    // 다운로드 버튼을 통해 리다이렉트한 주소에 대한 GET 요청
     @GetMapping("/result")
     public String result(@RequestParam("fbxUrl") String fbxUrl, Model model) {
         model.addAttribute("fbxUrl", fbxUrl);

--- a/src/main/java/com/alal/backend/controller/view/ViewController.java
+++ b/src/main/java/com/alal/backend/controller/view/ViewController.java
@@ -8,12 +8,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
 
 @Controller
@@ -59,11 +63,33 @@ public class ViewController {
         return "main/imagePage";
     }
 
-    // 웹에서 다운로드 버튼 클릭 시, 언리얼 엔진으로 전송
     @PostMapping("/send/fbx")
     @ResponseBody
     public ResponseEntity<FbxResponse> send(@RequestBody FbxRequest fbxRequest){
-        return ResponseEntity.ok(FbxResponse.fromFbxUrl(fbxRequest));
+        FbxResponse response = FbxResponse.fromFbxUrl(fbxRequest);
+        URI redirectUri = UriComponentsBuilder.fromPath("/view/result")
+                .queryParam("fbxUrl", response.getFbxUrl())
+                .build()
+                .toUri();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(redirectUri);
+        return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
+
+
+    @GetMapping("/result")
+    public String result(@RequestParam("fbxUrl") String fbxUrl, Model model) {
+        model.addAttribute("fbxUrl", fbxUrl);
+        return "main/result";
+    }
+
+
+
+    // 웹에서 다운로드 버튼 클릭 시, 언리얼 엔진으로 전송
+//    @PostMapping("/send/fbx")
+//    @ResponseBody
+//    public ResponseEntity<FbxResponse> send(@RequestBody FbxRequest fbxRequest){
+//        return ResponseEntity.ok(FbxResponse.fromFbxUrl(fbxRequest));
+//    }
 
 }

--- a/src/main/java/com/alal/backend/service/user/FlaskService.java
+++ b/src/main/java/com/alal/backend/service/user/FlaskService.java
@@ -1,0 +1,7 @@
+package com.alal.backend.service.user;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class FlaskService {
+}

--- a/src/main/java/com/alal/backend/service/user/MotionService.java
+++ b/src/main/java/com/alal/backend/service/user/MotionService.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ public class MotionService {
     @Value("${ai.model.serving.url}")
     private String flaskUrl;
 
+    // 동영상 파일 Flask 서버와 통신 후 url 응답
     @Transactional(readOnly = true)
     public Page<ViewResponse> findUrlByUploadMp4(MultipartFile file, Pageable pageable) {
         // MultipartFile을 base64 인코딩, 파일 형식 추출
@@ -45,6 +47,18 @@ public class MotionService {
         return new PageImpl<>(viewResponses, pageable, viewResponses.size());
     }
 
+    // 음성 파일 Flask 서버와 통신 후 base64 문자열 응답
+    public FlaskResponse uploadAndRespondWithAudioFileSuccess(MultipartFile voiceFile) {
+        // MultipartFile을 base64 인코딩, 파일 형식 추출
+        FlaskRequest flaskRequest = convertMultipartFileToBase64(voiceFile);
+
+        // Flask 서버 통신
+        FlaskResponse flaskResponse = communicateWithFlaskServerByVoice(flaskRequest);
+
+        return flaskResponse;
+    }
+
+
     // MultipartFile을 base64로 변환하는 메서드
     private FlaskRequest convertMultipartFileToBase64(MultipartFile file) {
         try {
@@ -58,7 +72,8 @@ public class MotionService {
         }
     }
 
-    // Flask 서버 통신
+
+    // Flask 서버 통신 (메세지 or 동영상 파일)
     private List<FlaskResponse> communicateWithFlaskServer(FlaskRequest flaskRequest) {
         // 파일을 Flask 서버로 전송
         List<FlaskResponse> flaskResponses =  webClient.post()
@@ -73,6 +88,43 @@ public class MotionService {
 
         return flaskResponses;
     }
+
+    // Flask 서버 통신 (음성)
+    private FlaskResponse communicateWithFlaskServerByVoice(FlaskRequest flaskRequest) {
+        FlaskResponse flaskResponse =  webClient.post()
+                .uri(flaskUrl + "/voice")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("voice", flaskRequest.getBase64EncodedFile(),
+                        "format", flaskRequest.getFileFormat()))
+                .retrieve()
+                .bodyToMono(FlaskResponse.class)
+                .block();
+
+        return flaskResponse;
+    }
+
+    // 메모리 억지로 늘리기
+//    private FlaskResponse communicateWithFlaskServerByVoice(FlaskRequest flaskRequest) {
+//        ExchangeStrategies strategies = ExchangeStrategies.builder()
+//                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(1024 * 1024 * 10))
+//                .build();
+//
+//        WebClient localWebClient = WebClient.builder()
+//                .exchangeStrategies(strategies)
+//                .build();
+//
+//        FlaskResponse flaskResponse = localWebClient.post()
+//                .uri(flaskUrl + "/voice")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .bodyValue(Map.of("voice", flaskRequest.getBase64EncodedFile(),
+//                        "format", flaskRequest.getFileFormat()))
+//                .retrieve()
+//                .bodyToMono(FlaskResponse.class)
+//                .block();
+//
+//        return flaskResponse;
+//    }
+
 
     // 메세지를 통한 gif, fbx 찾기
     @Transactional(readOnly = true)

--- a/src/main/resources/templates/main/imagePage.html
+++ b/src/main/resources/templates/main/imagePage.html
@@ -72,12 +72,16 @@
 
                 axios.post('/view/send/fbx', { 'fbxUrl': fbxUrl })
                     .then(function(response){
-                        console.log(fbxUrl);
+                        const redirectUrl = '/view/result?fbxUrl=' + encodeURIComponent(fbxUrl);
+                        console.log(response.headers.location);
+                        // window.location.replace(response.data.fbxUrl);
                         alert("다운로드 성공!");
+                        window.location.href = redirectUrl;
                     })
                     .catch(function(error){
                         alert("다운로드에 실패하였습니다.");
                     });
+
             });
         });
     });

--- a/src/main/resources/templates/main/result.html
+++ b/src/main/resources/templates/main/result.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Result</title>
+</head>
+<body>
+<h1>다운로드 완료 페이지</h1>
+</body>
+</html>

--- a/src/test/java/com/alal/backend/service/user/MotionServiceTest.java
+++ b/src/test/java/com/alal/backend/service/user/MotionServiceTest.java
@@ -1,30 +1,39 @@
 package com.alal.backend.service.user;
 
+import com.alal.backend.payload.response.FlaskResponse;
 import com.alal.backend.payload.response.ViewResponse;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
 
-import javax.swing.text.View;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class MotionServiceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @InjectMocks
     private MotionService motionService;
@@ -73,11 +82,12 @@ class MotionServiceTest {
         List<ViewResponse> expectedResponses = new ArrayList<>();
         ViewResponse viewResponse = ViewResponse.builder().build();
         viewResponse.setGifUrls(Arrays.asList("sampleGif1", "sampleGif2"));
+        viewResponse.setFbxUrls(Arrays.asList("sampleFbx1", "sampleFbx2"));
         expectedResponses.add(viewResponse);
 
         Page<ViewResponse> expectedPages = new PageImpl<>(expectedResponses, pageable, expectedResponses.size());
 
-        Mockito.when(motionServiceMock.findUrlByUploadMp4(mp4File,pageable)).thenReturn(expectedPages);
+        Mockito.when(motionServiceMock.findUrlByUploadMp4(mp4File, pageable)).thenReturn(expectedPages);
 
         // when
         Page<ViewResponse> resultPages = motionServiceMock.findUrlByUploadMp4(mp4File, pageable);
@@ -85,4 +95,31 @@ class MotionServiceTest {
         // then
         assertEquals(expectedPages.getContent(), resultPages.getContent());
     }
+
+//    @DisplayName("음성 파일을 정상적으로 업로드하여 클라이언트에 응답하는지")
+//    @Test
+//    void uploadAudioFileAndReceiveResponseTest() throws IOException {
+//        // given
+//        MockMultipartFile voiceFile = new MockMultipartFile(
+//                "sample",
+//                "sample.mp3",
+//                "audio/mpeg",
+//                "myFile".getBytes()
+//        );
+//
+//        FlaskResponse expectedResponse = new FlaskResponse("Expected response message");
+//
+//        // Assume that the service is a mock or spy.
+//        // You should replace 'motionService' with the actual name of your service instance.
+//        Mockito.when(motionService.uploadAndRespondWithAudioFileSuccess(voiceFile)).thenReturn(expectedResponse);
+//
+//        // when
+//        FlaskResponse actualResponse = motionService.uploadAndRespondWithAudioFileSuccess(voiceFile);
+//
+//        // then
+//        Assertions.assertNotNull(actualResponse, "The response should not be null");
+//        Assertions.assertNotEquals(expectedResponse.getResponseMessage(), actualResponse.getResponseMessage(),
+//                "The response message should match the expected message");
+//    }
+
 }


### PR DESCRIPTION
## 연관 이슈
이슈 번호 : #25 

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 음성 파일 받았을 때, flask 서버에 요청 보내고 base64 문자열 응답
- 현재 메모리 크기를 늘려 받을 수 있게 하였음
- 추후 flask 서버에서 구글 클라우드 스토리지에 업로드 후 해당 url을 응답하도록 바꿀 예정


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->

<img width="474" alt="image" src="https://github.com/MTVS-Post-Production/BackEnd/assets/105257665/c6ce41b8-be94-4611-8290-99051a84ac26">
