### PR TITLE
[베타] [그룹] 프로젝트 전체 조회 구현

### DIFF
--- a/src/main/java/com/alal/backend/advice/error/UserNotFoundException.java
+++ b/src/main/java/com/alal/backend/advice/error/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.alal.backend.advice.error;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String email) {
+        super(email + " 이 이메일을 가진 유저를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/alal/backend/config/security/SecurityConfig.java
+++ b/src/main/java/com/alal/backend/config/security/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
                         .permitAll()
                     .antMatchers("/login/**","/auth/**", "/oauth2/**"
                             , "/view/**"
-                            , "/group/**"
+                            , "/group/**", "/group/**/**"
                             , "/image/**"
                     )
                         .permitAll()

--- a/src/main/java/com/alal/backend/config/security/SecurityConfig.java
+++ b/src/main/java/com/alal/backend/config/security/SecurityConfig.java
@@ -86,9 +86,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
                     .antMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**")
                         .permitAll()
                     .antMatchers("/login/**","/auth/**", "/oauth2/**"
-                            , "/view/**"
-                            , "/group/**", "/group/**/**"
-                            , "/image/**"
+//                            , "/view/**"
+                            , "/group/**"
+                            , "/group/**/**"
+//                            , "/image/**"
                     )
                         .permitAll()
                     .antMatchers("/blog/**")

--- a/src/main/java/com/alal/backend/controller/user/GroupController.java
+++ b/src/main/java/com/alal/backend/controller/user/GroupController.java
@@ -1,8 +1,10 @@
 package com.alal.backend.controller.user;
 
 import com.alal.backend.domain.dto.request.UploadMemoRequest;
+import com.alal.backend.domain.dto.request.UploadProjectRequest;
 import com.alal.backend.domain.dto.response.ReadMemoResponse;
 import com.alal.backend.domain.dto.response.UploadMemoResponse;
+import com.alal.backend.domain.dto.response.UploadProjectResponse;
 import com.alal.backend.service.user.GroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +18,7 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping("/memo/upload")
-    public ResponseEntity<UploadMemoResponse> upload(@ModelAttribute UploadMemoRequest uploadMemoRequest
+    public ResponseEntity<UploadMemoResponse> upload(@RequestBody UploadMemoRequest uploadMemoRequest
 //    ,@CurrentUser UserPrincipal userPrincipal
     ) {
         Long userId = 1L;
@@ -29,5 +31,13 @@ public class GroupController {
     ) {
         Long userId = 1L;
         return ResponseEntity.ok(groupService.readMemos(userId));
+    }
+
+    @PostMapping("/project/upload")
+    public ResponseEntity<UploadProjectResponse> uploadProject(@RequestBody UploadProjectRequest uploadProjectRequest
+//    , @CurrentUser UserPrincipal userPrincipal
+                                                               ) {
+        Long userId = 1L;
+        return ResponseEntity.ok(groupService.uploadProject(uploadProjectRequest, userId));
     }
 }

--- a/src/main/java/com/alal/backend/controller/user/GroupController.java
+++ b/src/main/java/com/alal/backend/controller/user/GroupController.java
@@ -1,5 +1,8 @@
 package com.alal.backend.controller.user;
 
+import com.alal.backend.config.security.token.CurrentUser;
+import com.alal.backend.config.security.token.UserPrincipal;
+import com.alal.backend.domain.dto.response.ReadProjectsResponse;
 import com.alal.backend.domain.dto.request.UploadMemoRequest;
 import com.alal.backend.domain.dto.request.UploadProjectRequest;
 import com.alal.backend.domain.dto.response.ReadMemoResponse;
@@ -7,8 +10,13 @@ import com.alal.backend.domain.dto.response.UploadMemoResponse;
 import com.alal.backend.domain.dto.response.UploadProjectResponse;
 import com.alal.backend.service.user.GroupService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/group")
@@ -19,17 +27,19 @@ public class GroupController {
 
     @PostMapping("/memo/upload")
     public ResponseEntity<UploadMemoResponse> upload(@RequestBody UploadMemoRequest uploadMemoRequest
-//    ,@CurrentUser UserPrincipal userPrincipal
+    ,@CurrentUser UserPrincipal userPrincipal
     ) {
-        Long userId = 1L;
+//        Long userId = 1L;
+        Long userId = userPrincipal.getId();
         return ResponseEntity.ok(groupService.uploadMemo(uploadMemoRequest, userId));
     }
 
     @GetMapping("/memo")
     public ResponseEntity<ReadMemoResponse> read(
-//            ,@CurrentUser UserPrincipal userPrincipal
+            @CurrentUser UserPrincipal userPrincipal
     ) {
-        Long userId = 1L;
+//        Long userId = 1L;
+        Long userId = userPrincipal.getId();
         return ResponseEntity.ok(groupService.readMemos(userId));
     }
 
@@ -38,6 +48,16 @@ public class GroupController {
 //    , @CurrentUser UserPrincipal userPrincipal
                                                                ) {
         Long userId = 1L;
+//        Long userId = userPrincipal.getId();
         return ResponseEntity.ok(groupService.uploadProject(uploadProjectRequest, userId));
+    }
+
+    @GetMapping("/project/all")
+    public ResponseEntity<List<ReadProjectsResponse>> readProjects(@PageableDefault(value = 8) Pageable pageable
+//            , @CurrentUser UserPrincipal userPrincipal
+            ) {
+//        Long userId = userPrincipal.getId();
+        Long userId = 1L;
+        return ResponseEntity.ok(groupService.readProjects(userId, pageable).getContent());
     }
 }

--- a/src/main/java/com/alal/backend/controller/user/ImageController.java
+++ b/src/main/java/com/alal/backend/controller/user/ImageController.java
@@ -1,5 +1,7 @@
 package com.alal.backend.controller.user;
 
+import com.alal.backend.config.security.token.CurrentUser;
+import com.alal.backend.config.security.token.UserPrincipal;
 import com.alal.backend.domain.dto.request.UploadImageRequest;
 import com.alal.backend.domain.dto.response.ReadImageResponse;
 import com.alal.backend.domain.dto.response.UploadImageResponse;
@@ -21,17 +23,19 @@ public class ImageController {
     @Async
     @PostMapping("upload")
     public ResponseEntity<UploadImageResponse> upload(@RequestBody UploadImageRequest uploadImageRequest
-//                                                      ,@CurrentUser UserPrincipal userPrincipal
+                                                      ,@CurrentUser UserPrincipal userPrincipal
     ) {
-        Long userId = 1L;
+//        Long userId = 1L;
+        Long userId = userPrincipal.getId();
         return ResponseEntity.ok(imageService.uploadImage(uploadImageRequest, userId));
     }
 
     @GetMapping
     public ResponseEntity<Page<ReadImageResponse>> read(@PageableDefault(size = 18) Pageable pageable
-//                                                  , @CurrentUser UserPrincipal userPrincipal
+                                                  , @CurrentUser UserPrincipal userPrincipal
     ) {
-        Long userId = 1L;
+//        Long userId = 1L;
+        Long userId = userPrincipal.getId();
         return ResponseEntity.ok(imageService.readImages(userId, pageable));
     }
 }

--- a/src/main/java/com/alal/backend/controller/user/ViewController.java
+++ b/src/main/java/com/alal/backend/controller/user/ViewController.java
@@ -1,5 +1,7 @@
 package com.alal.backend.controller.user;
 
+import com.alal.backend.config.security.token.CurrentUser;
+import com.alal.backend.config.security.token.UserPrincipal;
 import com.alal.backend.payload.request.auth.FbxRequest;
 import com.alal.backend.payload.request.user.FlaskRequest;
 import com.alal.backend.payload.request.user.FlaskVoiceRequest;
@@ -10,7 +12,6 @@ import com.alal.backend.domain.dto.response.VoiceResponse;
 import com.alal.backend.service.user.MotionService;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -39,10 +40,10 @@ public class ViewController {
 
     @GetMapping
     public String motionPage(Model model,
-//                       @CurrentUser UserPrincipal userPrincipal,
+                       @CurrentUser UserPrincipal userPrincipal,
                              @PageableDefault(size = 12) Pageable pageable) {
-//        Long userId = userPrincipal.getId();
-        Long userId = 1L;
+        Long userId = userPrincipal.getId();
+//        Long userId = 1L;
         Page<ViewResponse> viewResponses = motionService.createViewResponse(userId, pageable);
 
         model.addAttribute("motionUrls", viewResponses);
@@ -54,10 +55,10 @@ public class ViewController {
     @PostMapping("/video")
     @ResponseBody
     public ResponseEntity<UpdateUserHistoryResponse> videoPost(@RequestBody FlaskRequest flaskRequest
-//                            ,@CurrentUser UserPrincipal userPrincipal
+                            ,@CurrentUser UserPrincipal userPrincipal
     ) {
-//        Long userId = userPrincipal.getId();
-        Long userId = 1L;
+        Long userId = userPrincipal.getId();
+//        Long userId = 1L;
         UpdateUserHistoryResponse updateUserHistoryResponse = motionService.findUrlByUploadMp4(flaskRequest, userId);
 
         return ResponseEntity.ok(updateUserHistoryResponse);
@@ -67,10 +68,10 @@ public class ViewController {
     @PostMapping("/voice")
     @ResponseBody
     public ResponseEntity<VoiceResponse> voicePost(@RequestBody FlaskVoiceRequest flaskRequest
-//                                                   ,@CurrentUser UserPrincipal userPrincipal
+                                                   ,@CurrentUser UserPrincipal userPrincipal
                                                    ) {
-        Long userId = 1L;
-//        Long userId = userPrincipal.getId();
+//        Long userId = 1L;
+        Long userId = userPrincipal.getId();
         VoiceResponse voiceResponse = motionService.uploadAndRespondWithAudioFileSuccess(flaskRequest, userId);
 
         return ResponseEntity.ok(voiceResponse);
@@ -103,11 +104,11 @@ public class ViewController {
     @GetMapping("/voice/result")
     @ResponseBody
     public ResponseEntity<VoiceResponse> getVoiceByUserId(
-//            @CurrentUser UserPrincipal userPrincipal,
+            @CurrentUser UserPrincipal userPrincipal,
             @RequestParam("modelName") String modelName
             ) {
-//        Long userId = userPrincipal.getId();
-        Long userId = 1L;
+        Long userId = userPrincipal.getId();
+//        Long userId = 1L;
         VoiceResponse voiceResponse = motionService.findByVoiceUrlWithUserId(userId, modelName);
 
         return ResponseEntity.ok(voiceResponse);
@@ -115,9 +116,10 @@ public class ViewController {
 
     @GetMapping("/filter")
     public String filterPage(@PageableDefault(size = 12) Pageable pageable, Model model, @RequestParam("motion") String motionName
-                             //            @CurrentUser UserPrincipal userPrincipal,
+                                         , @CurrentUser UserPrincipal userPrincipal
                              ) {
-        Long userId = 1L;
+//        Long userId = 1L;
+        Long userId = userPrincipal.getId();
         Page<ViewResponse> viewResponses = motionService.createViewResponseByMotionName(motionName, pageable, userId);
 
         model.addAttribute("motionUrls", viewResponses);

--- a/src/main/java/com/alal/backend/domain/dto/request/UploadMemoRequest.java
+++ b/src/main/java/com/alal/backend/domain/dto/request/UploadMemoRequest.java
@@ -7,9 +7,5 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @Setter
 public class UploadMemoRequest {
-    private MultipartFile csvFile;
-
-    public String getExt() {
-        return csvFile.getContentType();
-    }
+    private String csvFile;
 }

--- a/src/main/java/com/alal/backend/domain/dto/request/UploadProjectRequest.java
+++ b/src/main/java/com/alal/backend/domain/dto/request/UploadProjectRequest.java
@@ -1,0 +1,17 @@
+package com.alal.backend.domain.dto.request;
+
+import com.alal.backend.domain.dto.request.vo.StaffVO;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class UploadProjectRequest {
+    private String projectName;
+    private String description;
+    private List<StaffVO> staffs;
+    private List<String> avatarName;
+    private String poster;
+}

--- a/src/main/java/com/alal/backend/domain/dto/request/vo/StaffVO.java
+++ b/src/main/java/com/alal/backend/domain/dto/request/vo/StaffVO.java
@@ -1,0 +1,16 @@
+package com.alal.backend.domain.dto.request.vo;
+
+import com.alal.backend.domain.entity.user.StaffRole;
+import lombok.*;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Setter
+public class StaffVO {
+    private String email;
+    private StaffRole staffRole;
+}

--- a/src/main/java/com/alal/backend/domain/dto/response/ReadProjectsResponse.java
+++ b/src/main/java/com/alal/backend/domain/dto/response/ReadProjectsResponse.java
@@ -1,0 +1,19 @@
+package com.alal.backend.domain.dto.response;
+
+import com.alal.backend.domain.entity.user.Project;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReadProjectsResponse {
+    private String projectName;
+    private String posterUrl;
+
+    public static ReadProjectsResponse fromEntity(Project project) {
+        return ReadProjectsResponse.builder()
+                .projectName(project.getProjectName())
+                .posterUrl(project.getPoster())
+                .build();
+    }
+}

--- a/src/main/java/com/alal/backend/domain/dto/response/UploadProjectResponse.java
+++ b/src/main/java/com/alal/backend/domain/dto/response/UploadProjectResponse.java
@@ -1,0 +1,26 @@
+package com.alal.backend.domain.dto.response;
+
+import com.alal.backend.domain.entity.user.Project;
+import com.alal.backend.domain.entity.user.vo.Group;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class UploadProjectResponse {
+    private String projectName;
+    private String description;
+    private String posterName;
+    private Group group;
+
+    public static UploadProjectResponse fromEntity(Project project) {
+        return UploadProjectResponse.builder()
+                .projectName(project.getProjectName())
+                .description(project.getDescription())
+                .posterName(project.getProjectName())
+                .group(project.getGroup())
+                .build();
+    }
+}

--- a/src/main/java/com/alal/backend/domain/entity/user/Project.java
+++ b/src/main/java/com/alal/backend/domain/entity/user/Project.java
@@ -1,0 +1,55 @@
+package com.alal.backend.domain.entity.user;
+
+import com.alal.backend.domain.dto.request.UploadProjectRequest;
+import com.alal.backend.domain.entity.user.vo.Group;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Table
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Project {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    @Comment("프로젝트 번호")
+    private Long projectId;
+
+    @Column
+    @Comment("프로젝트명")
+    private String projectName;
+
+    @Column
+    @Comment("그룹명")
+    private Group group;
+
+    @Column
+    @Comment("설명")
+    private String description;
+
+    @Column
+    @Comment("포스터")
+    private String poster;
+
+    @OneToMany(mappedBy = "project")
+    private List<ProjectMember> projectMembers = new ArrayList<>();
+
+    public static Project fromDto(Group group, UploadProjectRequest uploadProjectRequest, String posterUrl) {
+        return Project.builder()
+                .group(group)
+                .projectName(uploadProjectRequest.getProjectName())
+                .description(uploadProjectRequest.getDescription())
+                .poster(posterUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/alal/backend/domain/entity/user/ProjectMember.java
+++ b/src/main/java/com/alal/backend/domain/entity/user/ProjectMember.java
@@ -1,0 +1,32 @@
+package com.alal.backend.domain.entity.user;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@Table
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ProjectMember {
+    @Id
+    @GeneratedValue
+    private Long projectMemberId;
+
+    @ManyToOne
+    @JoinColumn(name = "staff_id")
+    private Staff staff;
+
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    public static ProjectMember fromEntity(Staff staff, Project project) {
+        return ProjectMember.builder()
+                .staff(staff)
+                .project(project)
+                .build();
+    }
+}

--- a/src/main/java/com/alal/backend/domain/entity/user/Staff.java
+++ b/src/main/java/com/alal/backend/domain/entity/user/Staff.java
@@ -1,0 +1,48 @@
+package com.alal.backend.domain.entity.user;
+
+
+import com.alal.backend.domain.dto.request.vo.StaffVO;
+import com.alal.backend.domain.entity.user.vo.Group;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@Table
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Staff {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    @Comment("스태프 번호")
+    private Long staffId;
+
+    @Column
+    @Comment("유저 아이디")
+    private Long userId;
+
+    @Column
+    @Comment("역할")
+    private StaffRole staffRole;
+
+    @Column
+    @Comment("그룹명")
+    private Group group;
+
+    @OneToMany(mappedBy = "staff")
+    private List<ProjectMember> projectMembers = new ArrayList<>();
+
+    public static Staff fromVOAndUser(User user, StaffVO staffVO) {
+        return Staff.builder()
+                .userId(user.getId())
+                .group(new Group(user.getUserGroup()))
+                .staffRole(staffVO.getStaffRole())
+                .build();
+    }
+}

--- a/src/main/java/com/alal/backend/domain/entity/user/StaffRole.java
+++ b/src/main/java/com/alal/backend/domain/entity/user/StaffRole.java
@@ -1,0 +1,25 @@
+package com.alal.backend.domain.entity.user;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum StaffRole {
+    DIRECTER("directer"),
+    GENERAL("general");
+
+    private final String role;
+
+    StaffRole(String role) {
+        this.role = role;
+    }
+
+    @JsonCreator
+    public static StaffRole fromString(String value) {
+        for (StaffRole role : StaffRole.values()) {
+            if (role.role.equalsIgnoreCase(value)) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException("유요하지 않는 역할입니다.");
+    }
+
+}

--- a/src/main/java/com/alal/backend/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/alal/backend/repository/ProjectMemberRepository.java
@@ -1,0 +1,9 @@
+package com.alal.backend.repository;
+
+import com.alal.backend.domain.entity.user.ProjectMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
+}

--- a/src/main/java/com/alal/backend/repository/user/ProjectRepository.java
+++ b/src/main/java/com/alal/backend/repository/user/ProjectRepository.java
@@ -1,0 +1,9 @@
+package com.alal.backend.repository.user;
+
+import com.alal.backend.domain.entity.user.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/src/main/java/com/alal/backend/repository/user/ProjectRepository.java
+++ b/src/main/java/com/alal/backend/repository/user/ProjectRepository.java
@@ -1,9 +1,13 @@
 package com.alal.backend.repository.user;
 
 import com.alal.backend.domain.entity.user.Project;
+import com.alal.backend.domain.entity.user.vo.Group;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+    Page<Project> findAllByGroupOrderByProjectIdDesc(Group group, Pageable pageable);
 }

--- a/src/main/java/com/alal/backend/repository/user/StaffRepository.java
+++ b/src/main/java/com/alal/backend/repository/user/StaffRepository.java
@@ -1,0 +1,9 @@
+package com.alal.backend.repository.user;
+
+import com.alal.backend.domain.entity.user.Staff;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StaffRepository extends JpaRepository<Staff, Long> {
+}

--- a/src/main/java/com/alal/backend/repository/user/UserRepository.java
+++ b/src/main/java/com/alal/backend/repository/user/UserRepository.java
@@ -5,6 +5,7 @@ import com.alal.backend.domain.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +13,6 @@ public interface UserRepository extends JpaRepository<User,Long>{
     
     Optional<User> findByEmail(String email);
     Boolean existsByEmail(String email);
+
+    List<User> findByEmailIn(List<String> emails);
 }

--- a/src/main/java/com/alal/backend/service/user/GroupService.java
+++ b/src/main/java/com/alal/backend/service/user/GroupService.java
@@ -5,6 +5,7 @@ import com.alal.backend.domain.dto.request.UploadMemoRequest;
 import com.alal.backend.domain.dto.request.UploadProjectRequest;
 import com.alal.backend.domain.dto.request.vo.StaffVO;
 import com.alal.backend.domain.dto.response.ReadMemoResponse;
+import com.alal.backend.domain.dto.response.ReadProjectsResponse;
 import com.alal.backend.domain.dto.response.UploadMemoResponse;
 import com.alal.backend.domain.dto.response.UploadProjectResponse;
 import com.alal.backend.domain.entity.user.*;
@@ -19,6 +20,8 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -172,5 +175,14 @@ public class GroupService {
                 .filter(vo -> vo.getEmail().equals(email))
                 .findFirst()
                 .orElseThrow(() -> new UserNotFoundException(email));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ReadProjectsResponse> readProjects(Long userId, Pageable pageable) {
+        User user = getUser(userId);
+        Group group = getUserGroup(user);
+
+        return projectRepository.findAllByGroupOrderByProjectIdDesc(group, pageable)
+                .map(ReadProjectsResponse::fromEntity);
     }
 }

--- a/src/main/java/com/alal/backend/service/user/GroupService.java
+++ b/src/main/java/com/alal/backend/service/user/GroupService.java
@@ -1,12 +1,18 @@
 package com.alal.backend.service.user;
 
+import com.alal.backend.advice.error.UserNotFoundException;
 import com.alal.backend.domain.dto.request.UploadMemoRequest;
+import com.alal.backend.domain.dto.request.UploadProjectRequest;
+import com.alal.backend.domain.dto.request.vo.StaffVO;
 import com.alal.backend.domain.dto.response.ReadMemoResponse;
 import com.alal.backend.domain.dto.response.UploadMemoResponse;
-import com.alal.backend.domain.entity.user.Memo;
-import com.alal.backend.domain.entity.user.User;
+import com.alal.backend.domain.dto.response.UploadProjectResponse;
+import com.alal.backend.domain.entity.user.*;
 import com.alal.backend.domain.entity.user.vo.Group;
+import com.alal.backend.repository.ProjectMemberRepository;
 import com.alal.backend.repository.user.MemoRepository;
+import com.alal.backend.repository.user.ProjectRepository;
+import com.alal.backend.repository.user.StaffRepository;
 import com.alal.backend.repository.user.UserRepository;
 import com.alal.backend.utils.Parser;
 import com.google.cloud.storage.BlobInfo;
@@ -16,16 +22,19 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class GroupService {
     private final MemoRepository memoRepository;
     private final UserRepository userRepository;
-    private final Parser parser;
+    private final StaffRepository staffRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
 
+    private final Parser parser;
     private final Storage storage;
 
     @Value("${spring.cloud.gcp.storage.bucket}")
@@ -34,8 +43,7 @@ public class GroupService {
     @Transactional
     public UploadMemoResponse uploadMemo(UploadMemoRequest uploadMemoRequest, Long userId) {
         User user = getUser(userId);
-        String ext = uploadMemoRequest.getExt();
-        String uploadUrl = uploadStorage(user, ext);
+        String uploadUrl = uploadStorage(user, uploadMemoRequest);
 
         return saveMemo(uploadUrl, user);
     }
@@ -51,11 +59,14 @@ public class GroupService {
         return UploadMemoResponse.fromEntity(uploadUrl);
     }
 
-    private String uploadStorage(User user, String ext) {
+    private String uploadStorage(User user, UploadMemoRequest uploadMemoRequest) {
+        byte[] decodedBytes = Base64.getDecoder().decode(uploadMemoRequest.getCsvFile());
+
         BlobInfo blobInfo = storage.create(
-                BlobInfo.newBuilder(bucketName, user.getUserGroup())
-                        .setContentType(ext)
-                        .build()
+                BlobInfo.newBuilder(bucketName, user.getUserGroup() + ".csv")
+                        .setContentType("text/csv")
+                        .build(),
+                decodedBytes
         );
 
         return parser.parseBlobInfo(blobInfo);
@@ -85,5 +96,81 @@ public class GroupService {
             throw new NoSuchElementException("유저를 찾을 수 없습니다.");
         }
         return user.get();
+    }
+
+    @Transactional
+    public UploadProjectResponse uploadProject(UploadProjectRequest uploadProjectRequest, Long userId) {
+        List<Staff> staffs =saveStaff(uploadProjectRequest);
+        Project project = saveProject(uploadProjectRequest, userId);
+        addProjectMembers(staffs, project);
+
+        return UploadProjectResponse.fromEntity(project);
+    }
+
+    private void addProjectMembers(List<Staff> staffs, Project project) {
+        List<ProjectMember> projectMembers = new ArrayList<>();
+        for (Staff staff : staffs) {
+            ProjectMember projectMember = ProjectMember.fromEntity(staff, project);
+            projectMembers.add(projectMember);
+        }
+
+        projectMemberRepository.saveAll(projectMembers);
+    }
+
+    private Project saveProject(UploadProjectRequest uploadProjectRequest, Long userId) {
+        User user = getUser(userId);
+        Group group = getUserGroup(user);
+        String posterUrl = uploadPoster(uploadProjectRequest);
+        Project project = Project.fromDto(group, uploadProjectRequest, posterUrl);
+
+        return projectRepository.save(project);
+    }
+
+    private String uploadPoster(UploadProjectRequest uploadProjectRequest) {
+        byte[] decodedBytes = Base64.getDecoder().decode(uploadProjectRequest.getPoster());
+
+        BlobInfo blobInfo = storage.create(
+                BlobInfo.newBuilder(bucketName, uploadProjectRequest.getProjectName())
+                        .setContentType("image/png")
+                        .build(),
+                decodedBytes
+        );
+
+        return parser.parseBlobInfo(blobInfo);
+    }
+
+    private List<Staff> saveStaff(UploadProjectRequest uploadProjectRequest) {
+        List<String> emails = getEmailsFromStaffVOs(uploadProjectRequest);
+        List<User> users = getUsersByEmails(emails);
+        List<Staff> staffs = createStaffsFromUsers(users, uploadProjectRequest);
+
+        return staffRepository.saveAll(staffs);
+    }
+
+    private List<String> getEmailsFromStaffVOs(UploadProjectRequest uploadProjectRequest) {
+        return uploadProjectRequest.getStaffs().stream()
+                .map(StaffVO::getEmail)
+                .collect(Collectors.toList());
+    }
+
+    private List<User> getUsersByEmails(List<String> emails) {
+        return userRepository.findByEmailIn(emails);
+    }
+
+    private List<Staff> createStaffsFromUsers(List<User> users, UploadProjectRequest uploadProjectRequest) {
+        List<Staff> staffs = new ArrayList<>();
+        for (User user : users) {
+            StaffVO staffVO = getStaffVOByEmail(user.getEmail(), uploadProjectRequest);
+            Staff staff = Staff.fromVOAndUser(user, staffVO);
+            staffs.add(staff);
+        }
+        return staffs;
+    }
+
+    private StaffVO getStaffVOByEmail(String email, UploadProjectRequest uploadProjectRequest) {
+        return uploadProjectRequest.getStaffs().stream()
+                .filter(vo -> vo.getEmail().equals(email))
+                .findFirst()
+                .orElseThrow(() -> new UserNotFoundException(email));
     }
 }


### PR DESCRIPTION
## 연관 이슈
이슈 번호 : #65 

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 유저 아이디를 토대로 그룹을 특정한 후, 그룹에 해당하는 프로젝트 전체를 반환
- 페이징을 시행하나 현재 프론트에서 페이징 정보가 필요없기 때문에 List로 반환함
- 추후 프론트에서 페이징을 구현할 수 있으니 로직의 확장성을 염두해두고 Page 객체를 List 객체로 변환하는 작업을 시행함


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [ ] Yes
- [x] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->
<img width="853" alt="image" src="https://github.com/MTVS-Post-Production/BackEnd/assets/105257665/0fbaac73-ddfa-4881-b8cd-d89c92ae9f1e">
