### PR TITLE
[베타] [그룹] 프로젝트 상세 조회 쿼리 개선

### DIFF
--- a/src/main/java/com/alal/backend/controller/user/GroupController.java
+++ b/src/main/java/com/alal/backend/controller/user/GroupController.java
@@ -1,7 +1,5 @@
 package com.alal.backend.controller.user;
 
-import com.alal.backend.config.security.token.CurrentUser;
-import com.alal.backend.config.security.token.UserPrincipal;
 import com.alal.backend.domain.dto.request.UpdateAvatarRequest;
 import com.alal.backend.domain.dto.request.UploadMemoRequest;
 import com.alal.backend.domain.dto.request.UploadProjectRequest;
@@ -26,19 +24,19 @@ public class GroupController {
 
     @PostMapping("/memo/upload")
     public ResponseEntity<UploadMemoResponse> upload(@RequestBody UploadMemoRequest uploadMemoRequest
-    ,@CurrentUser UserPrincipal userPrincipal
+//    ,@CurrentUser UserPrincipal userPrincipal
     ) {
-//        Long userId = 1L;
-        Long userId = userPrincipal.getId();
+        Long userId = 1L;
+//        Long userId = userPrincipal.getId();
         return ResponseEntity.ok(groupService.uploadMemo(uploadMemoRequest, userId));
     }
 
     @GetMapping("/memo")
     public ResponseEntity<ReadMemoResponse> read(
-            @CurrentUser UserPrincipal userPrincipal
+//            @CurrentUser UserPrincipal userPrincipal
     ) {
-//        Long userId = 1L;
-        Long userId = userPrincipal.getId();
+        Long userId = 1L;
+//        Long userId = userPrincipal.getId();
         return ResponseEntity.ok(groupService.readMemos(userId));
     }
 
@@ -62,7 +60,11 @@ public class GroupController {
 
     @GetMapping("/project/{id}")
     public ResponseEntity<ReadProjectResponse> readProject(@PathVariable("id") Long projectId) {
-        return ResponseEntity.ok(groupService.readProject(projectId));
+        long start = System.nanoTime();
+        ReadProjectResponse readProjectResponse = groupService.readProject(projectId);
+        long end = System.nanoTime();
+        System.out.println("수행시간: " + (end - start) + " ns");
+        return ResponseEntity.ok(readProjectResponse);
     }
 
     @PatchMapping("/avatar")

--- a/src/main/java/com/alal/backend/controller/user/GroupController.java
+++ b/src/main/java/com/alal/backend/controller/user/GroupController.java
@@ -3,13 +3,12 @@ package com.alal.backend.controller.user;
 import com.alal.backend.config.security.token.CurrentUser;
 import com.alal.backend.config.security.token.UserPrincipal;
 import com.alal.backend.domain.dto.request.UpdateAvatarRequest;
-import com.alal.backend.domain.dto.response.*;
-import com.alal.backend.domain.dto.response.*;
 import com.alal.backend.domain.dto.request.UploadMemoRequest;
 import com.alal.backend.domain.dto.request.UploadProjectRequest;
+import com.alal.backend.domain.dto.response.*;
+import com.alal.backend.service.user.AvatarService;
 import com.alal.backend.service.user.GroupService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +22,7 @@ import java.util.List;
 public class GroupController {
 
     private final GroupService groupService;
+    private final AvatarService avatarService;
 
     @PostMapping("/memo/upload")
     public ResponseEntity<UploadMemoResponse> upload(@RequestBody UploadMemoRequest uploadMemoRequest
@@ -63,5 +63,10 @@ public class GroupController {
     @GetMapping("/project/{id}")
     public ResponseEntity<ReadProjectResponse> readProject(@PathVariable("id") Long projectId) {
         return ResponseEntity.ok(groupService.readProject(projectId));
+    }
+
+    @PatchMapping("/avatar")
+    public ResponseEntity<UpdateAvatarResponse> update(@RequestBody UpdateAvatarRequest avatarRequest) {
+        return ResponseEntity.ok(avatarService.updateAvatar(avatarRequest));
     }
 }

--- a/src/main/java/com/alal/backend/controller/user/ImageController.java
+++ b/src/main/java/com/alal/backend/controller/user/ImageController.java
@@ -23,19 +23,19 @@ public class ImageController {
     @Async
     @PostMapping("upload")
     public ResponseEntity<UploadImageResponse> upload(@RequestBody UploadImageRequest uploadImageRequest
-                                                      ,@CurrentUser UserPrincipal userPrincipal
+//                                                      ,@CurrentUser UserPrincipal userPrincipal
     ) {
-//        Long userId = 1L;
-        Long userId = userPrincipal.getId();
+        Long userId = 1L;
+//        Long userId = userPrincipal.getId();
         return ResponseEntity.ok(imageService.uploadImage(uploadImageRequest, userId));
     }
 
     @GetMapping
     public ResponseEntity<Page<ReadImageResponse>> read(@PageableDefault(size = 18) Pageable pageable
-                                                  , @CurrentUser UserPrincipal userPrincipal
+//                                                  , @CurrentUser UserPrincipal userPrincipal
     ) {
-//        Long userId = 1L;
-        Long userId = userPrincipal.getId();
+        Long userId = 1L;
+//        Long userId = userPrincipal.getId();
         return ResponseEntity.ok(imageService.readImages(userId, pageable));
     }
 }

--- a/src/main/java/com/alal/backend/controller/user/ViewController.java
+++ b/src/main/java/com/alal/backend/controller/user/ViewController.java
@@ -55,10 +55,10 @@ public class ViewController {
     @PostMapping("/video")
     @ResponseBody
     public ResponseEntity<UpdateUserHistoryResponse> videoPost(@RequestBody FlaskRequest flaskRequest
-                            ,@CurrentUser UserPrincipal userPrincipal
+//                            ,@CurrentUser UserPrincipal userPrincipal
     ) {
-        Long userId = userPrincipal.getId();
-//        Long userId = 1L;
+//        Long userId = userPrincipal.getId();
+        Long userId = 1L;
         UpdateUserHistoryResponse updateUserHistoryResponse = motionService.findUrlByUploadMp4(flaskRequest, userId);
 
         return ResponseEntity.ok(updateUserHistoryResponse);
@@ -116,10 +116,10 @@ public class ViewController {
 
     @GetMapping("/filter")
     public String filterPage(@PageableDefault(size = 12) Pageable pageable, Model model, @RequestParam("motion") String motionName
-                                         , @CurrentUser UserPrincipal userPrincipal
+//                                         , @CurrentUser UserPrincipal userPrincipal
                              ) {
-//        Long userId = 1L;
-        Long userId = userPrincipal.getId();
+        Long userId = 1L;
+//        Long userId = userPrincipal.getId();
         Page<ViewResponse> viewResponses = motionService.createViewResponseByMotionName(motionName, pageable, userId);
 
         model.addAttribute("motionUrls", viewResponses);

--- a/src/main/java/com/alal/backend/domain/dto/request/UpdateAvatarRequest.java
+++ b/src/main/java/com/alal/backend/domain/dto/request/UpdateAvatarRequest.java
@@ -1,5 +1,6 @@
 package com.alal.backend.domain.dto.request;
 
+import com.alal.backend.domain.info.AvatarInfo;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,6 +9,5 @@ import java.util.List;
 @Getter
 @Setter
 public class UpdateAvatarRequest {
-//    private List<AvatarInfo> avatarInfos;
-    private Long projectId;
+    private List<AvatarInfo> avatarInfos;
 }

--- a/src/main/java/com/alal/backend/domain/dto/response/ReadProjectResponse.java
+++ b/src/main/java/com/alal/backend/domain/dto/response/ReadProjectResponse.java
@@ -1,10 +1,8 @@
 package com.alal.backend.domain.dto.response;
 
+import com.alal.backend.domain.entity.project.*;
 import com.alal.backend.domain.info.AvatarInfo;
 import com.alal.backend.domain.info.StaffInfo;
-import com.alal.backend.domain.entity.project.Avatar;
-import com.alal.backend.domain.entity.project.Project;
-import com.alal.backend.domain.entity.project.Staff;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -43,5 +41,34 @@ public class ReadProjectResponse {
         return avatars.stream()
                 .map(AvatarInfo::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    public static ReadProjectResponse fromEntities(Project project) {
+        List<AvatarInfo> avatarInfos = extractAvatarInfos(project);
+        List<StaffInfo> staffInfos = extractStaffInfos(project);
+
+        return ReadProjectResponse.builder()
+                .projectName(project.getProjectName())
+                .description(project.getDescription())
+                .poster(project.getPoster())
+                .avatarInfo(avatarInfos)
+                .staffInfo(staffInfos)
+                .build();
+    }
+
+    private static List<StaffInfo> extractStaffInfos(Project project) {
+        return fromStaffList(
+                project.getProjectStaffs().stream()
+                        .map(ProjectStaff::getStaff)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    private static List<AvatarInfo> extractAvatarInfos(Project project) {
+        return fromAvatarList(
+                project.getProjectAvatars().stream()
+                        .map(ProjectAvatar::getAvatar)
+                        .collect(Collectors.toList())
+        );
     }
 }

--- a/src/main/java/com/alal/backend/domain/dto/response/UpdateAvatarResponse.java
+++ b/src/main/java/com/alal/backend/domain/dto/response/UpdateAvatarResponse.java
@@ -1,9 +1,29 @@
 package com.alal.backend.domain.dto.response;
 
+import com.alal.backend.domain.entity.project.Avatar;
+import com.alal.backend.domain.info.AvatarInfo;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
 public class UpdateAvatarResponse {
+    private List<AvatarInfo> avatarInfos;
+
+    public static UpdateAvatarResponse fromEntity(List<Avatar> avatars) {
+        List<AvatarInfo> avatarInfoFromAvatars = fromAvatarList(avatars);
+
+        return UpdateAvatarResponse.builder()
+                .avatarInfos(avatarInfoFromAvatars)
+                .build();
+    }
+
+    private static List<AvatarInfo> fromAvatarList(List<Avatar> avatars) {
+        return avatars.stream()
+                .map(AvatarInfo::fromEntity)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/alal/backend/domain/dto/response/UploadProjectResponse.java
+++ b/src/main/java/com/alal/backend/domain/dto/response/UploadProjectResponse.java
@@ -11,14 +11,12 @@ import lombok.Setter;
 public class UploadProjectResponse {
     private String projectName;
     private String description;
-    private String posterName;
     private String groupName;
 
     public static UploadProjectResponse fromEntity(Project project) {
         return UploadProjectResponse.builder()
                 .projectName(project.getProjectName())
                 .description(project.getDescription())
-                .posterName(project.getProjectName())
                 .groupName(project.getGroup().toString())
                 .build();
     }

--- a/src/main/java/com/alal/backend/domain/entity/project/Avatar.java
+++ b/src/main/java/com/alal/backend/domain/entity/project/Avatar.java
@@ -1,5 +1,6 @@
 package com.alal.backend.domain.entity.project;
 
+import com.alal.backend.domain.info.AvatarInfo;
 import com.alal.backend.domain.vo.Group;
 import lombok.*;
 import org.hibernate.annotations.Comment;
@@ -44,5 +45,26 @@ public class Avatar {
                 .avatarImage(DEFAULT_IMAGE)
                 .group(group)
                 .build();
+    }
+
+    public void update(String avatarUrl, AvatarInfo avatarInfo) {
+        updateAvatarName(avatarInfo.getAvatarName());
+        updateAvatarImage(avatarUrl);
+    }
+
+    private void updateAvatarName(String avatarName) {
+        if (avatarName != null) {
+            this.avatarName = avatarName;
+        }
+    }
+
+    private void updateAvatarImage(String avatarUrl) {
+        if (avatarImage != null) {
+            this.avatarImage = avatarUrl;
+        }
+    }
+
+    public void updateNameOnly(AvatarInfo avatarInfo) {
+        updateAvatarName(avatarInfo.getAvatarName());
     }
 }

--- a/src/main/java/com/alal/backend/domain/entity/project/Avatar.java
+++ b/src/main/java/com/alal/backend/domain/entity/project/Avatar.java
@@ -3,6 +3,7 @@ package com.alal.backend.domain.entity.project;
 import com.alal.backend.domain.info.AvatarInfo;
 import com.alal.backend.domain.vo.Group;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Comment;
 
 import javax.persistence.*;
@@ -19,7 +20,7 @@ public class Avatar {
     private static final String DEFAULT_IMAGE = "https://storage.googleapis.com/memo-log/defaultImage.png";
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column
     @Comment("배역 번호")
     private Long avatarId;
@@ -36,7 +37,7 @@ public class Avatar {
     @Comment("그룹명")
     private Group group;
 
-    @OneToMany(mappedBy = "avatar")
+    @OneToMany(mappedBy = "avatar", fetch = FetchType.LAZY)
     private List<ProjectAvatar> projectAvatars = new ArrayList<>();
 
     public static Avatar fromEntityAndName(Group group, String avatarName) {

--- a/src/main/java/com/alal/backend/domain/entity/project/Project.java
+++ b/src/main/java/com/alal/backend/domain/entity/project/Project.java
@@ -41,10 +41,10 @@ public class Project {
     @Comment("포스터")
     private String poster;
 
-    @OneToMany(mappedBy = "project")
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
     private List<ProjectStaff> projectStaffs = new ArrayList<>();
 
-    @OneToMany(mappedBy = "project")
+    @OneToMany(mappedBy = "project", fetch = FetchType.EAGER)
     private List<ProjectAvatar> projectAvatars = new ArrayList<>();
 
     public static Project fromDto(Group group, UploadProjectRequest uploadProjectRequest, String posterUrl) {

--- a/src/main/java/com/alal/backend/domain/entity/project/ProjectAvatar.java
+++ b/src/main/java/com/alal/backend/domain/entity/project/ProjectAvatar.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 public class ProjectAvatar {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long projectAvatarId;
 
     @ManyToOne

--- a/src/main/java/com/alal/backend/domain/entity/project/ProjectStaff.java
+++ b/src/main/java/com/alal/backend/domain/entity/project/ProjectStaff.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 public class ProjectStaff {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long projectMemberId;
 
     @ManyToOne

--- a/src/main/java/com/alal/backend/domain/entity/project/Staff.java
+++ b/src/main/java/com/alal/backend/domain/entity/project/Staff.java
@@ -44,7 +44,7 @@ public class Staff {
     @Comment("그룹명")
     private Group group;
 
-    @OneToMany(mappedBy = "staff")
+    @OneToMany(mappedBy = "staff", fetch = FetchType.LAZY)
     private List<ProjectStaff> projectStaffs = new ArrayList<>();
 
     public static Staff fromVOAndUser(User user, StaffVO staffVO) {

--- a/src/main/java/com/alal/backend/domain/info/AvatarInfo.java
+++ b/src/main/java/com/alal/backend/domain/info/AvatarInfo.java
@@ -7,11 +7,13 @@ import lombok.Getter;
 @Getter
 @Builder
 public class AvatarInfo {
+    private final Long avatarId;
     private final String avatarName;
     private final String avatarImage;
 
     public static AvatarInfo fromEntity(Avatar avatar) {
         return AvatarInfo.builder()
+                .avatarId(avatar.getAvatarId())
                 .avatarName(avatar.getAvatarName())
                 .avatarImage(avatar.getAvatarImage())
                 .build();

--- a/src/main/java/com/alal/backend/service/user/AvatarService.java
+++ b/src/main/java/com/alal/backend/service/user/AvatarService.java
@@ -1,0 +1,81 @@
+package com.alal.backend.service.user;
+
+import com.alal.backend.domain.dto.request.UpdateAvatarRequest;
+import com.alal.backend.domain.dto.response.UpdateAvatarResponse;
+import com.alal.backend.domain.entity.project.Avatar;
+import com.alal.backend.domain.info.AvatarInfo;
+import com.alal.backend.repository.user.AvatarRepository;
+import com.alal.backend.utils.Parser;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class AvatarService {
+    private final AvatarRepository avatarRepository;
+    private final Parser parser;
+    private final Storage storage;
+
+    @Value("${spring.cloud.gcp.storage.bucket}")
+    private String bucketName;
+
+    @Transactional
+    public UpdateAvatarResponse updateAvatar(UpdateAvatarRequest avatarRequest) {
+        List<Avatar> avatars = findAvatars(avatarRequest);
+        List<String> avatarUrls = uploadAvatarsAndGetUrls(avatarRequest.getAvatarInfos());
+
+        updateAvatars(avatars, avatarUrls, avatarRequest.getAvatarInfos());
+
+        return UpdateAvatarResponse.fromEntity(avatars);
+    }
+
+    private List<Avatar> findAvatars(UpdateAvatarRequest avatarRequest) {
+        return avatarRequest.getAvatarInfos().stream()
+                .map(avatarInfo -> avatarRepository.findByAvatarId(avatarInfo.getAvatarId()))
+                .collect(Collectors.toList());
+    }
+
+    private List<String> uploadAvatarsAndGetUrls(List<AvatarInfo> avatarInfos) {
+        return avatarInfos.stream()
+                .map(this::uploadAvatarAndGetUrl)
+                .collect(Collectors.toList());
+    }
+
+    private String uploadAvatarAndGetUrl(AvatarInfo avatarInfo) {
+        if (avatarInfo.getAvatarImage() == null || avatarInfo.getAvatarImage().isEmpty()) {
+            return null;
+        }
+        byte[] decodedBytes = Base64.getDecoder().decode(avatarInfo.getAvatarImage());
+
+        BlobInfo blobInfo = storage.create(
+                BlobInfo.newBuilder(bucketName, avatarInfo.getAvatarName())
+                        .setContentType("image/png")
+                        .build(),
+                decodedBytes
+        );
+
+        return parser.parseBlobInfo(blobInfo);
+    }
+
+    private void updateAvatars(List<Avatar> avatars, List<String> avatarUrls, List<AvatarInfo> avatarInfos) {
+        IntStream.range(0, avatars.size())
+                .forEach(i -> updateAvatar(avatars.get(i), avatarUrls.get(i), avatarInfos.get(i)));
+    }
+
+    private void updateAvatar(Avatar avatar, String avatarUrl, AvatarInfo avatarInfo) {
+        if (avatarUrl == null || avatarUrl.isEmpty()) {
+            avatar.updateNameOnly(avatarInfo);
+            return;
+        }
+        avatar.update(avatarUrl, avatarInfo);
+    }
+}

--- a/src/main/java/com/alal/backend/service/user/GroupService.java
+++ b/src/main/java/com/alal/backend/service/user/GroupService.java
@@ -220,17 +220,13 @@ public class GroupService {
     }
 
     private List<Staff> findStaffs(Project project) {
-        List<ProjectStaff> projectStaffs = projectMemberRepository.findAllByProject(project);
-
-        return projectStaffs.stream()
+        return project.getProjectStaffs().stream()
                 .map(ProjectStaff::getStaff)
                 .collect(Collectors.toList());
     }
 
     private List<Avatar> findAvatars(Project project) {
-        List<ProjectAvatar> projectAvatars = projectAvatarRepository.findAllByProject(project);
-
-        return projectAvatars.stream()
+        return project.getProjectAvatars().stream()
                 .map(ProjectAvatar::getAvatar)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 연관 이슈
이슈 번호 : #76 

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [x] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 상세 조회 시, 프로젝트와 연관되어 있는 쿼리를 각각 조사함
- 모든 자식 테이블을 조사하기 때문에 쿼리 자체는 올바르지만 과정이 반복되면 요청한 아바타의 개수 n * 요청한 스태프의 수 m 만큼의 쿼리가 생김
- 연관된 테이블을 fetch join을 통해 가져오도록 함


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [x] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->