### PR TITLE
refactor : 메모 덮어쓰기 시, 기존 메모 주소를 삭제하고 새로 업로드하도록 변경함

### DIFF
--- a/src/main/java/com/alal/backend/service/user/GroupService.java
+++ b/src/main/java/com/alal/backend/service/user/GroupService.java
@@ -45,18 +45,19 @@ public class GroupService {
     @Transactional
     public UploadMemoResponse uploadMemo(UploadMemoRequest uploadMemoRequest, Long userId) {
         User user = getUser(userId);
-        String uploadUrl = uploadStorage(user, uploadMemoRequest);
 
-        return saveMemo(uploadUrl, user);
+        return saveMemo(uploadMemoRequest, user);
     }
 
-    private UploadMemoResponse saveMemo(String uploadUrl, User user) {
+    private UploadMemoResponse saveMemo(UploadMemoRequest uploadMemoRequest, User user) {
         Memo memo = memoRepository.findByGroup(getUserGroup(user));
-
-        if (memo == null) {
-            Memo createdMemo = Memo.fromEntity(uploadUrl, user.getUserGroup());
-            memoRepository.save(createdMemo);
+        if (memo != null) {
+            memoRepository.delete(memo);
         }
+
+        String uploadUrl = uploadStorage(user, uploadMemoRequest);
+        Memo createdMemo = Memo.fromEntity(uploadUrl, user.getUserGroup());
+        memoRepository.save(createdMemo);
 
         return UploadMemoResponse.fromEntity(uploadUrl);
     }


### PR DESCRIPTION
## 연관 이슈
이슈 번호 : #97 

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [x] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 메모 덮어쓰기 시, 기존 메모 주소를 삭제하고 새로 업로드하도록 변경함
- 기존 방식으로는 메타데이터가 변경되지 않아 실제로는 덮어쓰기가 되었으나 구글 스토리지 url 내 정보는 바뀌지 않아 이전 정보가 보여짐


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [x] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->