### PR TITLE
[최종] [그룹] 씬 카드 전체 조회(다운로드)시 응답값에 대본 주소 추가함

### DIFF
--- a/src/main/java/com/alal/backend/domain/dto/response/ReadProjectsResponse.java
+++ b/src/main/java/com/alal/backend/domain/dto/response/ReadProjectsResponse.java
@@ -13,7 +13,6 @@ public class ReadProjectsResponse {
     private Long projectId;
     private String projectName;
     private String posterUrl;
-    private String script;
 
     public static ReadProjectsResponse fromEntity(Project project) throws IOException {
         String poster = Parser.downloadAndEncodeImage(project.getPoster());

--- a/src/main/java/com/alal/backend/domain/dto/response/ReadSceneResponseList.java
+++ b/src/main/java/com/alal/backend/domain/dto/response/ReadSceneResponseList.java
@@ -10,11 +10,13 @@ import java.util.List;
 @Getter
 public class ReadSceneResponseList {
     private List<ReadSceneResponse> readSceneResponses;
+    private String scriptUrl;
     private Long scriptId;
 
     public static ReadSceneResponseList from(List<ReadSceneResponse> readSceneResponses, Script script) {
         return ReadSceneResponseList.builder()
                 .readSceneResponses(readSceneResponses)
+                .scriptUrl(script.getScriptUrl())
                 .scriptId(script.getScriptId())
                 .build();
     }


### PR DESCRIPTION
## 연관 이슈
이슈 번호 : #111 

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Rename
- [ ] Test
- [x] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 씬 카드 전체 조회(다운로드)시 응답값에 대본 주소 추가함


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [x] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->